### PR TITLE
Helper methods to invoke code if object is a `something` or else invoke a fallback method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ class SomeClass:
 
 _Godot Traits_ includes a code generation tool that offers helper methods for declaring and utilizing traits. This tool actively monitors trait declarations and modifications, automatically generating a `GDScript` file named `gtraits.gd` in a configurable folder.
 
-Through this utility script, manipulating traits becomes easy and straightforward. It comprises four generic helper methods and four specific helper methods for each declared trait. For a trait named `Damageable`, the four methods are as follows:
+Through this utility script, manipulating traits becomes easy and straightforward. It comprises four generic helper methods and four specific helper methods for each declared trait. For a trait named `Damageable`, the six methods are as follows:
 - `set_damageable(object:Object) -> Damageable`: Applies the specified trait to make an object _Damageable_,
 - `is_damageable(object:Object) -> bool`: Checks if an object possesses the _Damageable_ trait,
 - `as_damageable(object:Object) -> Damageable`: Retrieves the _Damageable_ trait from the given object. This raises an error (in the form of a failed assertion) if the object _is not Damageable_,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Given that Godot Engine lacks an official interface system, many developers reso
 - [ ] Automatic dependent trait declaration and creation
 - [x] Generation of an helper script to provide strong typed features and code completion in editor
 - [ ] Inline traits into scripts by using the `@inline_trait(TheTraitName)` annotation
-- [ ] Helper methods to invoke code if object _is a [something]_ or else invoke a _fallback method_
+- [x] Helper methods to invoke code if object _is a [something]_ or else invoke a _fallback method_
 
 ## 📄 Examples
 
@@ -93,6 +93,8 @@ Through this utility script, manipulating traits becomes easy and straightforwar
 - `set_damageable(object:Object) -> Damageable`: Applies the specified trait to make an object _Damageable_,
 - `is_damageable(object:Object) -> bool`: Checks if an object possesses the _Damageable_ trait,
 - `as_damageable(object:Object) -> Damageable`: Retrieves the _Damageable_ trait from the given object. This raises an error (in the form of a failed assertion) if the object _is not Damageable_,
+- `if_is_damageable(object:Object, if_callable:Callable, deferred_call:bool = false) -> Variant`: Invoke the `if_callable` function on the object's _Damageable_ trait only if the object possesses the _Damageable_ trait. The `if_callable` function accepts only one argument: the _Damageable_ trait. The returned value is the callable result. If `deferred_call` is `true`, the callable is called using `call_deferred` method and the function returns `null`,
+- `if_is_damageable_or_else(object:Object, if_callable:Callable, else_callable:Callable, deferred_call:bool = false) -> Variant`: Invoke the `if_callable` function on the object's _Damageable_ trait only if the object possesses the _Damageable_ trait, or else invoke the `else_callable` callable. The `if_callable` function accepts only one argument: the _Damageable_ trait, and the `else_callable` takes no argument. The returned value is the callable result. If `deferred_call` is `true`, the callable is called using `call_deferred` method and the function returns `null`,
 - `unset_damageable(object:Object) -> void`: removes the _Damageable_ trait from the object.
 
 ```gdscript
@@ -111,16 +113,31 @@ func take_damage(damage:int) -> void:
 #####
 extends Node2D
 
+# #####
+# GTraits class contains damageable helpers since Godot Traits has automatically found the Damageable trait.
+# So we can write the following code
+# #####
+
 func _ready() -> void:
     var crate:Node2D = preload("crate.tscn").instantiate()
     add_child(crate)
+    GTraits.set_damageable(crate)
     crate.on_hit.connect(_on_crate_hit)
 
 func _on_crate_hit() -> void:
     var crate:Node2D = get_node("crate")
-    # GTraits class contains damageable helpers since Godot Traits has automatically found the Damageable trait.
     if GTraits.is_damageable(crate):
         GTraits.as_damageable(crate).take_damage(10)
+    # Can also be rewrite as follow
+    GTraits.if_is_damageable(crate, func(obj:Damageable): obj.take_damage(10))
+    # Can also be rewrite as follow
+    GTraits.if_is_damageable_or_else(
+        crate, 
+        func(obj:Damageable): obj.take_damage(10),
+        func(): print("I'm invicible!")
+    )
+    # Finally, can unset damageable trait
+    GTraits.unset_damageable(crate)
 ```
 
 _Godot Traits_ generation tool can also generate helper methods for _nested_ trait classes. As _nested_ class names may not be unique across the project and to prevent generating the same helper method twice, the generation tool utilizes the trait's _parent classes_ as context to create a unique helper name.
@@ -143,8 +160,8 @@ class Killable:
     pass
 
 # Will automatically generates helpers methods:
-# set_traits_some_class_damageable, is_traits_some_class_damageable, as_traits_some_class_damageable, unset_traits_some_class_damageable
-# set_traits_killable, is_traits_killable, as_traits_killable, unset_traits_killable
+# set_traits_some_class_damageable, is_traits_some_class_damageable, as_traits_some_class_damageable, unset_traits_some_class_damageable, if_is_traits_some_class_damageable, if_is_traits_some_class_damageable_or_else
+# set_traits_killable, is_traits_killable, as_traits_killable, unset_traits_killable, if_is_traits_killable, if_is_traits_killable_or_else
 ```
 
 _Godot Traits_ generation tool honors the _alias_ trait annotation parameter by creating helper methods named according to the specified alias.
@@ -169,8 +186,8 @@ class CriticalDamageable extends Damageable:
         return initial_damage * 2
 
 # Will automatically generates helpers methods:
-# set_critical_damageable, is_critical_damageable, as_critical_damageable, unset_critical_damageable
-# instead of creating helpers methods:
+# set_critical_damageable, is_critical_damageable, as_critical_damageable, unset_critical_damageable, if_is_critical_damageable, if_is_critical_damageable_or_else
+# instead of creating those helpers methods:
 # set_damageable_critical_damageable, ...
 ```
 

--- a/addons/godot-traits/core/gdscript/gtraits_gdscript_saver.gd
+++ b/addons/godot-traits/core/gdscript/gtraits_gdscript_saver.gd
@@ -51,7 +51,7 @@ func save(script_path:String, script_content:String) -> Script:
             break
 
     # Save it to FS
-    _do_save_script(script)
+    _do_save_script(script, script_path)
     # Emit that script has changed
     script.reload(false)
     script.emit_changed()
@@ -69,12 +69,12 @@ func _get_or_create_script(script_path:String) -> Script:
         script = load(script_path)
     else:
         script = GDScript.new()
-        script.resource_path = script_path
-        _do_save_script(script)
+        _do_save_script(script, script_path)
 
     return script
 
-func _do_save_script(script:Script) -> void:
+func _do_save_script(script:Script, script_path:String) -> void:
+    script.resource_path = script_path
     DirAccess.make_dir_recursive_absolute(script.resource_path.get_base_dir())
     var error = ResourceSaver.save(script, script.resource_path, ResourceSaver.FLAG_CHANGE_PATH)
     if error != OK:

--- a/addons/godot-traits/core/gtraits_core.gd
+++ b/addons/godot-traits/core/gtraits_core.gd
@@ -110,28 +110,46 @@ static func as_a(a_trait:Script, object:Object) -> Object:
 ## Calls the given [Callable] if and only if an object has a given trait. The callable
 ## takes the asked trait as argument. Returns the callable result if the object has the
 ## given trait, [code]null[/code] otherwise.
-## [br]
+## [br][br]
+## If [code]deferred_call[/code] is [code]true[/code], the callable is called using [method Callable.call_deferred] and
+## the returned value will always be [code]null[/code].
+## [br][br]
 ## See [method GTraitsCore.is_a] for more details about trait testing.
-static func if_is_a(a_trait:Script, object:Object, if_callable:Callable) -> Variant:
+static func if_is_a(a_trait:Script, object:Object, if_callable:Callable, deferred_call:bool = false) -> Variant:
     var trait_instance:Object = _traits_storage.get_trait_instance(object, a_trait)
     if trait_instance != null:
         assert(if_callable.is_valid(), "Callable must be valid")
-        return if_callable.call(trait_instance)
+        if deferred_call:
+            if_callable.call_deferred(trait_instance)
+            return null
+        else:
+            return if_callable.call(trait_instance)
     return null
 
 ## Calls the given [i]if[/i] [Callable] if and only if an object has a given trait, or else calls
 ## the given [i]else[/i] callable. The [i]if[/i] callable takes the asked trait as argument, and the
 ## [i]else[/i] callable does not take any argument. Returns the called callable result.
-## [br]
+## [br][br]
+## If [code]deferred_call[/code] is [code]true[/code], the callable is called using [method Callable.call_deferred] and
+## the returned value will always be [code]null[/code].
+## [br][br]
 ## See [method GTraitsCore.is_a] for more details about trait testing.
-static func if_is_a_or_else(a_trait:Script, object:Object, if_callable:Callable, else_callable:Callable) -> Variant:
+static func if_is_a_or_else(a_trait:Script, object:Object, if_callable:Callable, else_callable:Callable, deferred_call:bool = false) -> Variant:
     var trait_instance:Object = _traits_storage.get_trait_instance(object, a_trait)
     if trait_instance != null:
         assert(if_callable.is_valid(), "Callable must be valid")
-        return if_callable.call(trait_instance)
+        if deferred_call:
+            if_callable.call_deferred(trait_instance)
+            return null
+        else:
+            return if_callable.call(trait_instance)
     else:
         assert(else_callable.is_valid(), "Callable must be valid")
-        return else_callable.call()
+        if deferred_call:
+            else_callable.call_deferred()
+            return null
+        else:
+            return else_callable.call()
 
 #------------------------------------------
 # Private functions

--- a/addons/godot-traits/core/gtraits_core.gd
+++ b/addons/godot-traits/core/gtraits_core.gd
@@ -107,6 +107,32 @@ static func remove_trait_from(a_trait:Script, object:Object) -> void:
 static func as_a(a_trait:Script, object:Object) -> Object:
     return _traits_storage.get_trait_instance(object, a_trait, true)
 
+## Calls the given [Callable] if and only if an object has a given trait. The callable
+## takes the asked trait as argument. Returns the callable result if the object has the
+## given trait, [code]null[/code] otherwise.
+## [br]
+## See [method GTraitsCore.is_a] for more details about trait testing.
+static func if_is_a(a_trait:Script, object:Object, if_callable:Callable) -> Variant:
+    var trait_instance:Object = _traits_storage.get_trait_instance(object, a_trait)
+    if trait_instance != null:
+        assert(if_callable.is_valid(), "Callable must be valid")
+        return if_callable.call(trait_instance)
+    return null
+
+## Calls the given [i]if[/i] [Callable] if and only if an object has a given trait, or else calls
+## the given [i]else[/i] callable. The [i]if[/i] callable takes the asked trait as argument, and the
+## [i]else[/i] callable does not take any argument. Returns the called callable result.
+## [br]
+## See [method GTraitsCore.is_a] for more details about trait testing.
+static func if_is_a_or_else(a_trait:Script, object:Object, if_callable:Callable, else_callable:Callable) -> Variant:
+    var trait_instance:Object = _traits_storage.get_trait_instance(object, a_trait)
+    if trait_instance != null:
+        assert(if_callable.is_valid(), "Callable must be valid")
+        return if_callable.call(trait_instance)
+    else:
+        assert(else_callable.is_valid(), "Callable must be valid")
+        return else_callable.call()
+
 #------------------------------------------
 # Private functions
 #------------------------------------------

--- a/addons/godot-traits/examples/dynamic-add-remove-trait/main.gd
+++ b/addons/godot-traits/examples/dynamic-add-remove-trait/main.gd
@@ -35,8 +35,10 @@ func _process(delta: float) -> void:
 
     if _ellapsed_time > 1:
         _ellapsed_time = 0
-        if GTraits.is_damageable(_npc):
-            GTraits.as_damageable(_npc).take_damage(1)
+        GTraits.if_is_damageable(_npc, func(damageable:Damageable): damageable.take_damage(5))
+        # Can also be write as:
+        #if GTraits.is_damageable(_npc):
+            #GTraits.as_damageable(_npc).take_damage(1)
 
 #------------------------------------------
 # Public functions
@@ -48,11 +50,12 @@ func _process(delta: float) -> void:
 
 func _on_incibility_timer_timeout() -> void:
     # NPC has trait CriticalDamageable, but we cn remote it using it's super class Damageable
-    if GTraits.is_damageable(_npc):
-        print("Removing damageable trait !")
-        GTraits.unset_damageable(_npc)
-    else:
-        print("Adding damageable trait !")
-        # Is not critical anymore !
-        GTraits.set_damageable(_npc)
+    # Can also be write as:
+    GTraits.if_is_damageable_or_else(_npc, func(any): GTraits.unset_damageable(_npc), func(): GTraits.set_damageable(_npc))
+    ## Can also be write as:
+    #if GTraits.is_damageable(_npc):
+        #GTraits.unset_damageable(_npc)
+    #else:
+        ## Is not critical anymore !
+        #GTraits.set_damageable(_npc)
 

--- a/addons/godot-traits/helper/gtraits_helper_generator.gd
+++ b/addons/godot-traits/helper/gtraits_helper_generator.gd
@@ -336,7 +336,7 @@ func _generate_gtraits_helper() -> void:
 
             generated_traits.append(trait_name_alias if not trait_name_alias.is_empty() else trait_full_name)
 
-    _gdscript_saver.save(_gtraits_script_path, content)
+    _gdscript_saver.save(GTraitsEditorSettings.get_instance().get_gtraits_helper_output_path(), content)
 
 func _get_indent_string() -> String:
     var indent_type:GTraitsEditorSettings.IndentType = GTraitsEditorSettings.get_instance().get_editor_indent_type()

--- a/addons/godot-traits/helper/gtraits_helper_generator.gd
+++ b/addons/godot-traits/helper/gtraits_helper_generator.gd
@@ -256,6 +256,14 @@ func _generate_gtraits_helper() -> void:
     content += "static func remove_trait_from(a_trait:Script, object:Object) -> void:\n"
     content += indent_string + "GTraitsCore.remove_trait_from(a_trait, object)\n"
     content += "\n"
+    content += "## Shortcut for [method GTraitsCore.if_is_a]\n"
+    content += "static func if_is_a(a_trait:Script, object:Object, if_callable:Callable) -> Variant:\n"
+    content += indent_string + "return GTraitsCore.if_is_a(a_trait, object, if_callable)\n"
+    content += "\n"
+    content += "## Shortcut for [method GTraitsCore.if_is_a_or_else]\n"
+    content += "static func if_is_a_or_else(a_trait:Script, object:Object, if_callable:Callable, else_callable:Callable) -> Variant:\n"
+    content += indent_string + "return GTraitsCore.if_is_a_or_else(a_trait, object, if_callable, else_callable)\n"
+    content += "\n"
     content += "#endregion\n"
     content += "\n"
     var generated_traits:PackedStringArray = []
@@ -307,6 +315,20 @@ func _generate_gtraits_helper() -> void:
                 content += "static func unset_%s(object:Object) -> void:\n" % snaked_trait_full_name
                 content += indent_string + "remove_trait_from(%s, object)\n" % trait_full_name
                 content += "\n"
+                content += "## Calls the given [Callable] if and only if an object is a [%s]. The callable.\n" % trait_full_name
+                content += "## takes the [%s] trait as argument. Returns the callable result if the object is a\n" % trait_full_name
+                content += "## [%s], [code]null[/code] otherwise.\n" % trait_full_name
+                content += "## See [method GTraits.if_is_a] for more details.\n"
+                content += "static func if_is_%s(object:Object, if_callable:Callable) -> Variant:\n" % snaked_trait_full_name
+                content += indent_string + "return if_is_a(%s, object, if_callable)\n" % trait_full_name
+                content += "\n"
+                content += "## Calls the given [i]if[/i] [Callable] if and only if an object is a [%s], or else calls\n" % trait_full_name
+                content += "## the given [i]else[/i] callable. The [i]if[/i] callable takes the [%s] trait as argument, and the\n" % trait_full_name
+                content += "## [i]else[/i] callable does not take any argument. Returns the called callable result..\n"
+                content += "## See [method GTraits.if_is_a_or_else] for more details.\n"
+                content += "static func if_is_%s_or_else(object:Object, if_callable:Callable, else_callable:Callable) -> Variant:\n" % snaked_trait_full_name
+                content += indent_string + "return if_is_a_or_else(%s, object, if_callable, else_callable)\n" % trait_full_name
+                content += "\n"
             else:
                 content += "# Trait %s is configured to be accessed by alias %s" % [trait_full_name, trait_name_alias]
                 content += "\n\n"
@@ -329,6 +351,20 @@ func _generate_gtraits_helper() -> void:
                 content += "## See [method GTraits.remove_trait_from] for more details.\n"
                 content += "static func unset_%s(object:Object) -> void:\n" % snaked_trait_name_alias
                 content += indent_string + "remove_trait_from(%s, object)\n" % trait_full_name
+                content += "\n"
+                content += "## Calls the given [Callable] if and only if an object is a [%s] as trait alias [b]%s[/b]. The callable.\n" % [trait_full_name, trait_name_alias]
+                content += "## takes the [%s] trait as argument. Returns the callable result if the object is a\n" % trait_full_name
+                content += "## [%s], [code]null[/code] otherwise.\n" % trait_full_name
+                content += "## See [method GTraits.if_is_a] for more details.\n"
+                content += "static func if_is_%s(object:Object, if_callable:Callable) -> Variant:\n" % snaked_trait_name_alias
+                content += indent_string + "return if_is_a(%s, object, if_callable)\n" % trait_full_name
+                content += "\n"
+                content += "## Calls the given [i]if[/i] [Callable] if and only if an object is a [%s] as trait alias [b]%s[/b], or else calls\n" % [trait_full_name, trait_name_alias]
+                content += "## the given [i]else[/i] callable. The [i]if[/i] callable takes the [%s] trait as argument, and the\n" % trait_full_name
+                content += "## [i]else[/i] callable does not take any argument. Returns the called callable result..\n"
+                content += "## See [method GTraits.if_is_a_or_else] for more details.\n"
+                content += "static func if_is_%s_or_else(object:Object, if_callable:Callable, else_callable:Callable) -> Variant:\n" % snaked_trait_name_alias
+                content += indent_string + "return if_is_a_or_else(%s, object, if_callable, else_callable)\n" % trait_full_name
                 content += "\n"
 
             content += "#endregion\n"

--- a/addons/godot-traits/helper/gtraits_helper_generator.gd
+++ b/addons/godot-traits/helper/gtraits_helper_generator.gd
@@ -257,12 +257,12 @@ func _generate_gtraits_helper() -> void:
     content += indent_string + "GTraitsCore.remove_trait_from(a_trait, object)\n"
     content += "\n"
     content += "## Shortcut for [method GTraitsCore.if_is_a]\n"
-    content += "static func if_is_a(a_trait:Script, object:Object, if_callable:Callable) -> Variant:\n"
-    content += indent_string + "return GTraitsCore.if_is_a(a_trait, object, if_callable)\n"
+    content += "static func if_is_a(a_trait:Script, object:Object, if_callable:Callable, deferred_call:bool = false) -> Variant:\n"
+    content += indent_string + "return GTraitsCore.if_is_a(a_trait, object, if_callable, deferred_call)\n"
     content += "\n"
     content += "## Shortcut for [method GTraitsCore.if_is_a_or_else]\n"
-    content += "static func if_is_a_or_else(a_trait:Script, object:Object, if_callable:Callable, else_callable:Callable) -> Variant:\n"
-    content += indent_string + "return GTraitsCore.if_is_a_or_else(a_trait, object, if_callable, else_callable)\n"
+    content += "static func if_is_a_or_else(a_trait:Script, object:Object, if_callable:Callable, else_callable:Callable, deferred_call:bool = false) -> Variant:\n"
+    content += indent_string + "return GTraitsCore.if_is_a_or_else(a_trait, object, if_callable, else_callable, deferred_call)\n"
     content += "\n"
     content += "#endregion\n"
     content += "\n"
@@ -318,16 +318,24 @@ func _generate_gtraits_helper() -> void:
                 content += "## Calls the given [Callable] if and only if an object is a [%s]. The callable.\n" % trait_full_name
                 content += "## takes the [%s] trait as argument. Returns the callable result if the object is a\n" % trait_full_name
                 content += "## [%s], [code]null[/code] otherwise.\n" % trait_full_name
+                content += "## [br][br]\n"
+                content += "## If [code]deferred_call[/code] is [code]true[/code], the callable is called using [method Callable.call_deferred] and\n"
+                content += "## the returned value will always be [code]null[/code].\n"
+                content += "## [br][br]\n"
                 content += "## See [method GTraits.if_is_a] for more details.\n"
-                content += "static func if_is_%s(object:Object, if_callable:Callable) -> Variant:\n" % snaked_trait_full_name
-                content += indent_string + "return if_is_a(%s, object, if_callable)\n" % trait_full_name
+                content += "static func if_is_%s(object:Object, if_callable:Callable, deferred_call:bool = false) -> Variant:\n" % snaked_trait_full_name
+                content += indent_string + "return if_is_a(%s, object, if_callable, deferred_call)\n" % trait_full_name
                 content += "\n"
                 content += "## Calls the given [i]if[/i] [Callable] if and only if an object is a [%s], or else calls\n" % trait_full_name
                 content += "## the given [i]else[/i] callable. The [i]if[/i] callable takes the [%s] trait as argument, and the\n" % trait_full_name
                 content += "## [i]else[/i] callable does not take any argument. Returns the called callable result..\n"
+                content += "## [br][br]\n"
+                content += "## If [code]deferred_call[/code] is [code]true[/code], the callable is called using [method Callable.call_deferred] and\n"
+                content += "## the returned value will always be [code]null[/code].\n"
+                content += "## [br][br]\n"
                 content += "## See [method GTraits.if_is_a_or_else] for more details.\n"
-                content += "static func if_is_%s_or_else(object:Object, if_callable:Callable, else_callable:Callable) -> Variant:\n" % snaked_trait_full_name
-                content += indent_string + "return if_is_a_or_else(%s, object, if_callable, else_callable)\n" % trait_full_name
+                content += "static func if_is_%s_or_else(object:Object, if_callable:Callable, else_callable:Callable, deferred_call:bool = false) -> Variant:\n" % snaked_trait_full_name
+                content += indent_string + "return if_is_a_or_else(%s, object, if_callable, else_callable, deferred_call)\n" % trait_full_name
                 content += "\n"
             else:
                 content += "# Trait %s is configured to be accessed by alias %s" % [trait_full_name, trait_name_alias]
@@ -355,16 +363,24 @@ func _generate_gtraits_helper() -> void:
                 content += "## Calls the given [Callable] if and only if an object is a [%s] as trait alias [b]%s[/b]. The callable.\n" % [trait_full_name, trait_name_alias]
                 content += "## takes the [%s] trait as argument. Returns the callable result if the object is a\n" % trait_full_name
                 content += "## [%s], [code]null[/code] otherwise.\n" % trait_full_name
+                content += "## [br][br]\n"
+                content += "## If [code]deferred_call[/code] is [code]true[/code], the callable is called using [method Callable.call_deferred] and\n"
+                content += "## the returned value will always be [code]null[/code].\n"
+                content += "## [br][br]\n"
                 content += "## See [method GTraits.if_is_a] for more details.\n"
-                content += "static func if_is_%s(object:Object, if_callable:Callable) -> Variant:\n" % snaked_trait_name_alias
-                content += indent_string + "return if_is_a(%s, object, if_callable)\n" % trait_full_name
+                content += "static func if_is_%s(object:Object, if_callable:Callable, deferred_call:bool = false) -> Variant:\n" % snaked_trait_name_alias
+                content += indent_string + "return if_is_a(%s, object, if_callable, deferred_call)\n" % trait_full_name
                 content += "\n"
                 content += "## Calls the given [i]if[/i] [Callable] if and only if an object is a [%s] as trait alias [b]%s[/b], or else calls\n" % [trait_full_name, trait_name_alias]
                 content += "## the given [i]else[/i] callable. The [i]if[/i] callable takes the [%s] trait as argument, and the\n" % trait_full_name
-                content += "## [i]else[/i] callable does not take any argument. Returns the called callable result..\n"
+                content += "## [i]else[/i] callable does not take any argument. Returns the called callable result.\n"
+                content += "## [br][br]\n"
+                content += "## If [code]deferred_call[/code] is [code]true[/code], the callable is called using [method Callable.call_deferred] and\n"
+                content += "## the returned value will always be [code]null[/code].\n"
+                content += "## [br][br]\n"
                 content += "## See [method GTraits.if_is_a_or_else] for more details.\n"
-                content += "static func if_is_%s_or_else(object:Object, if_callable:Callable, else_callable:Callable) -> Variant:\n" % snaked_trait_name_alias
-                content += indent_string + "return if_is_a_or_else(%s, object, if_callable, else_callable)\n" % trait_full_name
+                content += "static func if_is_%s_or_else(object:Object, if_callable:Callable, else_callable:Callable, deferred_call:bool = false) -> Variant:\n" % snaked_trait_name_alias
+                content += indent_string + "return if_is_a_or_else(%s, object, if_callable, else_callable, deferred_call)\n" % trait_full_name
                 content += "\n"
 
             content += "#endregion\n"


### PR DESCRIPTION
Add `GTraits`core methods:
- `if_is_a(a_trait:Script, object:Object, if_callable:Callable, call_deferred:bool = false) -> Variant`
- `if_is_a_or_else(a_trait:Script, object:Object, if_callable:Callable, else_callable:Callable, call_deferred:bool = false) -> Variant`

Automatically generate trait specific helpers methods in `GTraits`  