### PR TITLE
Create command "Regenerate GTraits Script"

### DIFF
--- a/addons/godot-traits/godot-traits.gd
+++ b/addons/godot-traits/godot-traits.gd
@@ -44,7 +44,7 @@ func _unhandled_key_input(event: InputEvent) -> void:
             if event.is_released():
                 _regenerate_gtraits_script()
 
-func _regenerate_gtraits_script():
+func _regenerate_gtraits_script() -> void:
     GTraitsFileSystem.get_instance().force_full_scan()
     GTraitsHelperGenerator.get_instance().clear_and_regenerate()
     _logger.info(func(): return "🎭 Godot Traits: GTraits script regenerated in '%s'" % GTraitsEditorSettings.get_instance().get_gtraits_helper_output_path())

--- a/addons/godot-traits/godot-traits.gd
+++ b/addons/godot-traits/godot-traits.gd
@@ -7,6 +7,7 @@ class_name GodotTraitsEditorPlugin
 ##
 
 static var _instance:GodotTraitsEditorPlugin
+const commandKey_RegenGTraitsScript = "gtraits/regenerate-gtraits-script"
 
 # Logger
 var _logger:GTraitsLogger = GTraitsLogger.new("gtraits_plugin")
@@ -21,10 +22,16 @@ func _enter_tree() -> void:
         GTraitsFileSystem.get_instance().initialize()
         GTraitsEditorSettings.get_instance().initialize()
         GTraitsHelperGenerator.get_instance().initialize()
+        EditorInterface.get_command_palette().add_command(
+            "Regenerate GTraits Script",
+            commandKey_RegenGTraitsScript,
+            Callable(self, "regenerate_gtraits_script"),
+            GTraitsEditorSettings.get_instance().get_gtraits_helper_regeneration_shortcut().get_as_text())
         _logger.info(func(): return "🎭 Godot Traits loaded !")
 
 func _exit_tree() -> void:
     if Engine.is_editor_hint():
+        EditorInterface.get_command_palette().remove_command(commandKey_RegenGTraitsScript)
         GTraitsHelperGenerator.get_instance().uninitialize()
         GTraitsEditorSettings.get_instance().uninitialize()
         GTraitsFileSystem.get_instance().uninitialize()
@@ -35,6 +42,9 @@ func _unhandled_key_input(event: InputEvent) -> void:
     if Engine.is_editor_hint():
         if GTraitsEditorSettings.get_instance().get_gtraits_helper_regeneration_shortcut().matches_event(event):
             if event.is_released():
-                GTraitsFileSystem.get_instance().force_full_scan()
-                GTraitsHelperGenerator.get_instance().clear_and_regenerate()
-                _logger.info(func(): return "🎭 Godot Traits: GTraits script regenerated in '%s'" % GTraitsEditorSettings.get_instance().get_gtraits_helper_output_path())
+                regenerate_gtraits_script()
+
+func regenerate_gtraits_script():
+    GTraitsFileSystem.get_instance().force_full_scan()
+    GTraitsHelperGenerator.get_instance().clear_and_regenerate()
+    _logger.info(func(): return "🎭 Godot Traits: GTraits script regenerated in '%s'" % GTraitsEditorSettings.get_instance().get_gtraits_helper_output_path())

--- a/addons/godot-traits/godot-traits.gd
+++ b/addons/godot-traits/godot-traits.gd
@@ -7,7 +7,7 @@ class_name GodotTraitsEditorPlugin
 ##
 
 static var _instance:GodotTraitsEditorPlugin
-const commandKey_RegenGTraitsScript = "gtraits/regenerate-gtraits-script"
+const _palette_command_key_regen_script = "gtraits/regenerate-gtraits-script"
 
 # Logger
 var _logger:GTraitsLogger = GTraitsLogger.new("gtraits_plugin")
@@ -24,14 +24,14 @@ func _enter_tree() -> void:
         GTraitsHelperGenerator.get_instance().initialize()
         EditorInterface.get_command_palette().add_command(
             "Regenerate GTraits Script",
-            commandKey_RegenGTraitsScript,
+            _palette_command_key_regen_script,
             Callable(self, "regenerate_gtraits_script"),
             GTraitsEditorSettings.get_instance().get_gtraits_helper_regeneration_shortcut().get_as_text())
         _logger.info(func(): return "🎭 Godot Traits loaded !")
 
 func _exit_tree() -> void:
     if Engine.is_editor_hint():
-        EditorInterface.get_command_palette().remove_command(commandKey_RegenGTraitsScript)
+        EditorInterface.get_command_palette().remove_command(_palette_command_key_regen_script)
         GTraitsHelperGenerator.get_instance().uninitialize()
         GTraitsEditorSettings.get_instance().uninitialize()
         GTraitsFileSystem.get_instance().uninitialize()
@@ -42,9 +42,9 @@ func _unhandled_key_input(event: InputEvent) -> void:
     if Engine.is_editor_hint():
         if GTraitsEditorSettings.get_instance().get_gtraits_helper_regeneration_shortcut().matches_event(event):
             if event.is_released():
-                regenerate_gtraits_script()
+                _regenerate_gtraits_script()
 
-func regenerate_gtraits_script():
+func _regenerate_gtraits_script():
     GTraitsFileSystem.get_instance().force_full_scan()
     GTraitsHelperGenerator.get_instance().clear_and_regenerate()
     _logger.info(func(): return "🎭 Godot Traits: GTraits script regenerated in '%s'" % GTraitsEditorSettings.get_instance().get_gtraits_helper_output_path())


### PR DESCRIPTION
This exposes the regenerate functionality to the user through the Editor > Command Palette menu in addition to the keyboard shortcut.

- Refactor Ctrl+Alt+U shortcut action to a separate function
- Register that function as a command when we _enter_tree
- De-register the function when we _exit_tree