### PR TITLE
Fixed typo in required container type.

### DIFF
--- a/addons/godot-traits/core/gtraits_storage.gd
+++ b/addons/godot-traits/core/gtraits_storage.gd
@@ -149,7 +149,7 @@ func _get_scene_trait_container_for(receiver:Node, trait_instance:Node) -> Node:
         elif required_container_type == "Node2D":
             container = preload("res://addons/godot-traits/core/container/gtraits_container_2d.tscn").instantiate()
             #container.name = "GTraitsContainer2D"
-        elif required_container_type == "Node2D":
+		elif required_container_type == "Node3D":
             container = preload("res://addons/godot-traits/core/container/gtraits_container_3d.tscn").instantiate()
             #container.name = "GTraitsContainer3D"
         else:


### PR DESCRIPTION
Check for Node3D to set container as gtraits_container_3d.tscn