### PR TITLE
Multiple traits in container

### DIFF
--- a/addons/godot-traits/core/container/gtraits_container.gd
+++ b/addons/godot-traits/core/container/gtraits_container.gd
@@ -65,10 +65,14 @@ func _set_trait_container_type() -> void:
     set_meta(GTraitsStorage.META_KEY_CONTAINER_TYPE, "Node")
 
 func _on_child_order_changed() -> void:
-    for child in get_children():
-        # Check if invalid node is present or not
-        if child.get_meta(_META_KEY_NOT_A_TRAIT, false):
-            continue
+	# Check if the container is still in the tree
+	if not is_inside_tree():
+		return
+	
+	for child in get_children():
+		# Check if invalid node is present or not
+		if child.get_meta(_META_KEY_NOT_A_TRAIT, false):
+			continue
 
         # Flag invalid node
         if not GTraitsTypeOracle.get_instance().is_trait(child.get_script()):

--- a/addons/godot-traits/core/gtraits_storage.gd
+++ b/addons/godot-traits/core/gtraits_storage.gd
@@ -149,7 +149,7 @@ func _get_scene_trait_container_for(receiver:Node, trait_instance:Node) -> Node:
         elif required_container_type == "Node2D":
             container = preload("res://addons/godot-traits/core/container/gtraits_container_2d.tscn").instantiate()
             #container.name = "GTraitsContainer2D"
-        elif required_container_type == "Node2D":
+		elif required_container_type == "Node3D":
             container = preload("res://addons/godot-traits/core/container/gtraits_container_3d.tscn").instantiate()
             #container.name = "GTraitsContainer3D"
         else:


### PR DESCRIPTION
Added a check to ensure the GTraitsContainer is still in the tree before updating the traits when child_order_changed is triggered. This removes an issue where removing a node with multiple traits in a container creates a null reference errror.