### PR TITLE
Trait automatic dependencies removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ The stable version (_1.x_) is compatible with Godot 4.4 and above. For users on 
 - ~~[ ] Inline traits into scripts using the `@inline_trait(TheTraitName)` annotation~~ (Requires extensive lexer/parser/AST implementation)
 - [x] Helper methods for conditional trait-based code execution
 - [x] Trait instantiation optimization (caching trait instantiation info)
-- [ ] Automatic cleanup of unused trait dependencies upon removal
-- [ ] Mixins (group of traits)
+- [x] Automatic cleanup of unused trait dependencies upon removal
 - [ ] Project traits (boosted Autoloads)
 
 ## 🚀 Quick Start
@@ -437,6 +436,46 @@ func _init() -> void:
     assert(GTraits.is_damageable(crate), "It is Damageable!")
     assert(GTraits.is_loggable(crate), "It is Loggable too!")
     assert(GTraits.is_healthable(crate), "It is Healthable too!")
+```
+
+Godot Traits provides fine-grained control over dependency lifecycle management. By default, when a trait is removed from a receiver, its injected dependencies are automatically cleaned up, unless they were explicitly added or are still required by other traits.
+
+This behavior can be customized using the `on_destroy` annotation parameter, which accepts two values:
+
+- `destroy_dependencies` (default): Automatically remove injected dependencies when the trait is destroyed
+- `keep_dependencies`: Retain all dependencies in the receiver even after trait removal
+
+Here's an example demonstrating both behaviors:
+
+```gdscript
+#####
+# File damageable1.gd
+#####
+# @trait(on_destroy=destroy_dependencies)
+class_name Damageable1
+
+var _healthable: Healthable
+var _loggable: Loggable
+
+func _init(healthable: Healthable, loggable: Loggable) -> void:
+    _healthable = healthable
+    _loggable = loggable
+    # Those dependencies will be removed from the receiver when the Damageable1 trait is removed
+
+#####
+# File damageable2.gd
+#####
+
+# @trait(on_destroy=keep_dependencies)
+class_name Damageable2
+
+var _healthable: Healthable
+var _loggable: Loggable
+
+func _init(healthable: Healthable, loggable: Loggable) -> void:
+    _healthable = healthable
+    _loggable = loggable
+    # Those dependencies will remains into the receiver even if Damageable2 trait is removed
 ```
 
 ##### 📜 Dependency Injection Rules

--- a/addons/godot-traits/core/container/gtraits_container.gd
+++ b/addons/godot-traits/core/container/gtraits_container.gd
@@ -103,7 +103,7 @@ func _initialize_trait(a_trait_instance: Node) -> void:
     # there is a check to enure that it will be done only once
     GTraitsTraitInitializerRegistry.get_instance() \
         .get_initialize_initializer(the_trait) \
-        .invoke(GTraitsTraitBuilder.new(), receiver, a_trait_instance)
+        .invoke(GTraitsTraitBuilder.new(), receiver, a_trait_instance, true)
 
     # Save trait instance into the receiver trait instances storage
     var trait_storage: GTraitsStorage = GTraitsStorage.get_instance()

--- a/addons/godot-traits/core/gdscript/gtraits_type_oracle.gd
+++ b/addons/godot-traits/core/gdscript/gtraits_type_oracle.gd
@@ -125,8 +125,9 @@ func filter_super_script_types_and_sub_script_types_of(scripts: Array[Script], s
 
 ## Declare a class as a trait, making it available for dependency injection. If the scene path is not empty,
 ## the given scene will be instantiated instead of the given script when a trait instance will be needed
-func register_trait(a_trait: Script, a_trait_name: String, scene_path: String = "") -> void:
+func register_trait(a_trait: Script, a_trait_name: String, on_destroy_destroy_dependencies: bool = true, scene_path: String = "") -> void:
     _known_traits[a_trait] = TraitInfo.new(a_trait_name, a_trait, scene_path)
+    a_trait.set_meta("__trait_on_destroy_destroy_dependencies", on_destroy_destroy_dependencies)
 
 ## Returns [code]true[/code] is the given class is a trait, [code]false[/code] otherwise.
 func is_trait(script: Script) -> bool:

--- a/addons/godot-traits/core/gtraits_core.gd
+++ b/addons/godot-traits/core/gtraits_core.gd
@@ -70,8 +70,11 @@ class_name GTraitsCore
 ## [br][br]
 ## If the [code]scene_path[/code] is not empty, the trait is registered as a [i]Scene trait[/i]. When
 ## used, the scene will be instantiated instead of the trait script.
-static func register_trait(a_trait: Script, a_trait_name: String, scene_path: String = "") -> void:
-    GTraitsTypeOracle.get_instance().register_trait(a_trait, a_trait_name, scene_path)
+## [br][br]
+## If [code]on_destroy_destroy_dependencies[/code] is [code]true[/code], the trait will destroy its dependencies
+## when it is destroyed.
+static func register_trait(a_trait: Script, a_trait_name: String, on_destroy_destroy_dependencies: bool = true, scene_path: String = "") -> void:
+    GTraitsTypeOracle.get_instance().register_trait(a_trait, a_trait_name, on_destroy_destroy_dependencies, scene_path)
 
 ## Returns [code]true[/code] if an object has a given trait, [code]false[/code] otherwise.
 static func is_a(a_trait: Script, object: Object) -> bool:

--- a/addons/godot-traits/helper/gtraits_helper_generator.gd
+++ b/addons/godot-traits/helper/gtraits_helper_generator.gd
@@ -267,15 +267,20 @@ func _generate_gtraits_helper() -> void:
 
             for qualified_trait_name in sorted_trait_qualified_names:
                 var the_trait: GTraitsGDScriptParser.ClassInfo = traits[qualified_trait_name]
+                var the_trait_on_destroy_policy: String = the_trait.annotations['trait'].options['on_destroy'] if the_trait.annotations['trait'].options.has("on_destroy") else 'destroy_dependencies'
+                if the_trait_on_destroy_policy != 'destroy_dependencies' and the_trait_on_destroy_policy != 'keep_dependencies':
+                    _logger.warn(func(): return "⚠️ Trait '%s' has an invalid on_destroy policy: '%s'. It will be ignored." % [the_trait.qualified_class_name, the_trait_on_destroy_policy])
+                    the_trait_on_destroy_policy = 'destroy_dependencies'
+                var the_trait_on_destroy_cascade: bool = the_trait_on_destroy_policy == 'destroy_dependencies'
                 if _scene_paths_by_script_path.has_key(the_trait.script_path):
                     var scene_paths: Array = _scene_paths_by_script_path.get_values(the_trait.script_path)
                     if scene_paths.size() == 1:
-                        registry_content += indent_string + "GTraitsCore.register_trait(%s, \"%s\", \"%s\")\n" % [the_trait.qualified_class_name, the_trait.qualified_class_name, scene_paths.front()]
+                        registry_content += indent_string + "GTraitsCore.register_trait(%s, \"%s\", %s, \"%s\")\n" % [the_trait.qualified_class_name, the_trait.qualified_class_name, the_trait_on_destroy_cascade, scene_paths.front()]
                     else:
                         _logger.warn(func(): return "⚠️ Multiple scenes are using script trait '%s' as root script. It will not be declared as a Scene trait." % the_trait.qualified_class_name)
-                        registry_content += indent_string + "GTraitsCore.register_trait(%s, \"%s\")\n" % [the_trait.qualified_class_name, the_trait.qualified_class_name]
+                        registry_content += indent_string + "GTraitsCore.register_trait(%s, \"%s\", %s)\n" % [the_trait.qualified_class_name, the_trait.qualified_class_name, the_trait_on_destroy_cascade]
                 else:
-                    registry_content += indent_string + "GTraitsCore.register_trait(%s, \"%s\")\n" % [the_trait.qualified_class_name, the_trait.qualified_class_name]
+                    registry_content += indent_string + "GTraitsCore.register_trait(%s, \"%s\", %s)\n" % [the_trait.qualified_class_name, the_trait.qualified_class_name, the_trait_on_destroy_cascade]
     registry_content += "\n"
     registry_content += "#endregion\n\n"
 


### PR DESCRIPTION
Now,when a trait is removed, all its dependencies are also removed:
- if they are not used anymore
- and if they are not top level dependencies (added manually)

This behavior can be controlled using the annotation parameter `on_destroy` :
- `destroy_dependencies` (default if not specified): destroy dependencies
- `keep_dependencies`: keep all dependencies into the receiver, even if not used by any remaining trait